### PR TITLE
Add link to GitHub project to the Contributing section

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -15,7 +15,9 @@
 %h2 Contributing
 
 %p
-  You can contribute in any way that you would like.  Add a meetup for your city, send a
+  You can contribute to 
+  %a{href: 'https://github.com/elixir-community/elixir.community'} the GitHub project
+  in any way that you would like.  Add a meetup for your city, send a
   pull-request that fixes my terrible markup,
   %a{href: 'https://github.com/elixir-community/elixir.community/issues'} raise an issue
   to tell me the font sucks.


### PR DESCRIPTION
Hi,

cool project! One thing: I had to look wayyyy to long for a link to your repo.

This PR contains a suggestion where one such link could work.

But maybe you should put a BIG link at the end of that page (because your link color is pretty similar to your text color on my monitor).

Keep up the great work! :+1: 
