### PR TITLE
updated us meetup links to not include elixir.community as the fqdn

### DIFF
--- a/views/meetups/us.haml
+++ b/views/meetups/us.haml
@@ -11,13 +11,13 @@
         short talks, programming, and concurrent networking.
       %li
         RSVP on
-        %a{href: 'www.meetup.com/Bay-Area-Elixir-Meetup/'} meetup.com
+        %a{href: 'http://www.meetup.com/Bay-Area-Elixir-Meetup/'} meetup.com
   %li
     Boston Elixir
     %ul
       %li
-        Meet other Elixir enthusiasts! This meetup will try to meet on a regular basis to 
+        Meet other Elixir enthusiasts! This meetup will try to meet on a regular basis to
         share knowledge on the Elixir programming language.
       %li
         RSVP on
-        %a{href: 'www.meetup.com/Boston-Elixir/'} meetup.com
+        %a{href: 'http://www.meetup.com/Boston-Elixir/'} meetup.com


### PR DESCRIPTION
The links on the meetup page under US were taking me to `http://elixir.community/www.meetup.com/Bay-Area-Elixir-Meetup/` instead of `www.meetup.com/Bay-Area-Elixir-Meetup/`.

The links for other countries had the protocol prefixed to the FQDN and did not have this behavior. I updated the US links to match.